### PR TITLE
updated to the atom-workspace tag

### DIFF
--- a/keymaps/node-debugger.cson
+++ b/keymaps/node-debugger.cson
@@ -7,6 +7,6 @@
 
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
-'.workspace':
+'atom-workspace':
   'ctrl-alt-n': 'node-debugger:toggle'
   'ctrl-alt-t': 'node-debugger:breakpoint-toggle'


### PR DESCRIPTION
the .workspace class is deprecated, updated to the atom-workspace tag.