### PR TITLE
updated to use .atom-text-editor tag

### DIFF
--- a/stylesheets/gutter-breakpoint.less
+++ b/stylesheets/gutter-breakpoint.less
@@ -1,4 +1,4 @@
-.atom-text-editor .gutter .line-number.gutter-breakpoint {
+atom-text-editor .gutter .line-number.gutter-breakpoint {
 
   .icon-right {
     visibility: visible;

--- a/stylesheets/gutter-breakpoint.less
+++ b/stylesheets/gutter-breakpoint.less
@@ -1,4 +1,4 @@
-.editor .gutter .line-number.gutter-breakpoint {
+.atom-text-editor .gutter .line-number.gutter-breakpoint {
 
   .icon-right {
     visibility: visible;


### PR DESCRIPTION
The .editor tag has been deprecated and replaced with the .atom-text-editor tag.