### PR TITLE
Bug fix: handle premature node process exit

### DIFF
--- a/lib/debugger.coffee
+++ b/lib/debugger.coffee
@@ -77,7 +77,7 @@ class ProcessManager extends EventEmitter
     new Promise (resolve, reject) =>
       return resolve() if not @process?
       if @process.exitCode
-        logger.info 'child_process_children', 'process already exited with code ' + @process.exitcode
+        logger.info 'child_process', 'process already exited with code ' + @process.exitcode
         @process = null
         return resolve()
 

--- a/lib/debugger.coffee
+++ b/lib/debugger.coffee
@@ -76,6 +76,10 @@ class ProcessManager extends EventEmitter
     self = this
     new Promise (resolve, reject) =>
       return resolve() if not @process?
+      if @process.exitCode
+        logger.info 'child_process_children', 'process already exited with code ' + @process.exitcode
+        @process = null
+        return resolve()
 
       onProcessEnd = R.once =>
         logger.info 'child_process', 'die'


### PR DESCRIPTION
Problem description: If there is a compile time error the node process will exit and the cleanup method is not able to recover