### PR TITLE
Bug fix: Handle premature node process exit during cleanup

### DIFF
--- a/lib/debugger.coffee
+++ b/lib/debugger.coffee
@@ -76,6 +76,10 @@ class ProcessManager extends EventEmitter
     self = this
     new Promise (resolve, reject) =>
       return resolve() if not @process?
+      if @process.exitCode
+        logger.info 'child_process', 'process already exited with code ' + @process.exitcode
+        @process = null
+        return resolve()
 
       onProcessEnd = R.once =>
         logger.info 'child_process', 'die'


### PR DESCRIPTION
Problem description: The node process might exit prematurely if the code does not compile.