### PR TITLE
Bug fix: View scrollbar when console log overflows

### DIFF
--- a/lib/Components/ConsolePane.coffee
+++ b/lib/Components/ConsolePane.coffee
@@ -91,7 +91,8 @@ exports.create = (_debugger) ->
     }, [
       h('div.debugger-panel-heading', {}, ['stdout/stderr'])
       h('div.panel-body.padded', style: {
-        flex: 'auto'
+        flex: '1'
+        overflow: 'auto'
       }, state.lines.map(tokenizeLine))
       h('div.debugger-editor', style: {
         height: '33px'


### PR DESCRIPTION
See https://github.com/kiddkai/atom-node-debugger/issues/53.