### PR TITLE
Process management robustness and error messages improved

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ node-debugger package
 
 ## Usage
 
-Check in the node-debugger package settings that the node path is set correctly.
 Open a javascript (.js) file and execute the start-resume command (F5) to launch the debugger.
 
 Debug panels will show up as shown in the image below.
@@ -45,6 +44,10 @@ The following attributes can be set to control the node-debugger.
   appArgs: ""
   debugPort: 5860
 ```
+
+## Troubleshooting
+
+Check in the node-debugger package settings that the node path is set correctly.
 
 ## Feedback
 

--- a/lib/Components/ConsolePane.coffee
+++ b/lib/Components/ConsolePane.coffee
@@ -76,7 +76,7 @@ exports.create = (_debugger) ->
           next()
       })
 
-    _debugger.processManager.on 'procssCreated', ->
+    _debugger.processManager.on 'processCreated', ->
       {stdout, stderr} = _debugger.processManager.process
 
       stdout.on 'data', (d) -> console.log(d.toString())

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "atom-space-pen-views": "^2.0.5",
     "bluebird": "^2.9.25",
     "bunyan": "^1.3.5",
+    "child-process-promise": "^1.1.0",
     "emissary": "^1.3.0",
     "event-stream": "^3.3.1",
     "geval": "^2.1.1",
@@ -24,6 +25,7 @@
     "xtend": "^4.0.0"
   },
   "devDependencies": {
-    "from": "^0.1.3"
+    "from": "^0.1.3",
+    "q": "^1.4.1"
   }
 }

--- a/spec/src/debugger-spec.coffee
+++ b/spec/src/debugger-spec.coffee
@@ -1,13 +1,13 @@
-childprocess = require 'child_process'
+childprocess = require 'child-process-promise'
 {EventEmitter} = require 'events'
 {ProcessManager} = require '../../lib/debugger'
 Stream = require 'stream'
+Q = require('q')
 
 makeFakeProcess = () ->
   process = new EventEmitter()
   process.stdout = new Stream()
   process.stderr = new Stream()
-
   return process
 
 describe 'ProcessManager', ->
@@ -27,7 +27,7 @@ describe 'ProcessManager', ->
         config:
           get: (key) -> mapping[key]
 
-      spyOn(childprocess, 'spawn').andReturn(makeFakeProcess())
+      spyOn(childprocess, 'spawn').andReturn(Q.fcall(makeFakeProcess))
 
       manager = new ProcessManager(atomStub)
       waitsForPromise () ->


### PR DESCRIPTION
One problem that initial users may bump into is that the node executable is not found which may be a result of a missing configuration (node-debugger.nodePath).

This pr tries to improve on the process management and gives a decent error message in the case above (and other cases too).