### PR TITLE
Better user feedback on invalid path to node executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ node-debugger package
 
 ## Usage
 
-Check in the node-debugger package settings that the node path is set correctly.
 Open a javascript (.js) file and execute the start-resume command (F5) to launch the debugger.
 
 Debug panels will show up as shown in the image below.
@@ -45,6 +44,10 @@ The following attributes can be set to control the node-debugger.
   appArgs: ""
   debugPort: 5860
 ```
+
+## Troubleshooting
+
+Check in the node-debugger package settings that the node path is set correctly.
 
 ## Feedback
 

--- a/lib/debugger.coffee
+++ b/lib/debugger.coffee
@@ -54,9 +54,20 @@ class ProcessManager extends EventEmitter
 
         @emit 'procssCreated', @process
 
-        @process.once 'error', (e) =>
-          logger.error 'child_process error', e
-          @emit 'processEnd', e
+        @process.once 'error', (err) =>
+          switch err.code
+            when "ENOENT"
+              logger.error 'child_process', "ENOENT exit code. Message: #{err.message}"
+              atom.notifications.addError(
+                "Failed to start debugger.
+                Exit code was ENOENT which indicates that the node
+                executable could not be found.
+                Try specifying an explicit path in your atom config file
+                using the node-debugger.nodePath configuration setting."
+              )
+            else
+              logger.error 'child_process', "Exit code #{err.code}. #{err.message}"
+          @emit 'processEnd', err
 
         @process.once 'close', () =>
           logger.info 'child_process', 'close'


### PR DESCRIPTION
This is a problem that initial users may bump into and by giving a
decent error message they can be guided to change their configuration
(node-debugger.nodePath)