### PR TITLE
Fix missing node arguments

### DIFF
--- a/lib/debugger.coffee
+++ b/lib/debugger.coffee
@@ -19,6 +19,7 @@ class ProcessManager extends EventEmitter
     @cleanup()
       .then =>
         nodePath = @atom.config.get('node-debugger.nodePath')
+        nodeArgs = @atom.config.get('node-debugger.nodeArgs')
         appArgs = @atom.config.get('node-debugger.appArgs')
         port = @atom.config.get('node-debugger.debugPort')
 
@@ -28,6 +29,7 @@ class ProcessManager extends EventEmitter
           .getPath()
 
         args = [
+          nodeArgs or ''
           "--debug-brk=#{port}"
           file or appPath
           appArgs or ''


### PR DESCRIPTION
Noticed that the flags I was passing via the "Node Args" field (`nodeArgs`) were being ignored. There are no references to `nodeArgs` in the code.