### PR TITLE
add management via a debug file

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,21 @@ The following attributes can be set to control the node-debugger.
   debugPort: 5860
 ```
 
+### Project
+
+Put a file named *node-debug.json* in your root project, and it will be automatically used.
+Here an example of content:
+
+```json
+{
+  "env": {
+    "NODE_ENV": "true"
+  },
+  "cwd": ".",
+  "main": "lib"
+}
+```
+
 ## Troubleshooting
 
 Check in the node-debugger package settings that the node path is set correctly.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,18 +1,18 @@
 version: "{build}"
 os: Windows Server 2012 R2
- 
+
 test: off
 deploy: off
- 
+
 init:
   - cmd: rd /s /q %CHOCOLATEYINSTALL%
   - ps: iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))
- 
+
 install:
-  - cinst atom
+  - cinst --yes atom
   - cd %APPVEYOR_BUILD_FOLDER%
-  - apm install
- 
+  - "%LOCALAPPDATA%/atom/bin/apm install"
+
 build_script:
   - cd %APPVEYOR_BUILD_FOLDER%
-  - apm test
+  - "%LOCALAPPDATA%/atom/bin/apm test"


### PR DESCRIPTION
- Added management of environment variable
- Added definition of 'project' and 'entry point' thanks to *node-debug.json*

- Place a *node-debug.json* in the project root and it will be discovered by the plugin automatically

Here an example of *node-debug.json* file:
```json
{
  "env": {
    "NODE_ENV": "true"
  },
  "cwd": ".",
  "main": "lib"
}
```

_Note:_
Locally ``apm test`` works.