### PR TITLE
Bugfix of splitters

### DIFF
--- a/lib/Components/App.coffee
+++ b/lib/Components/App.coffee
@@ -27,7 +27,7 @@ RightSidePane = (BreakPointPane, CallStackPane, LocalsPane, StepButton, state) -
   h('div', {
     style: {
       display: 'flex'
-      witdh: "#{state.sideWidth}px"
+      width: "#{state.sideWidth}px"
       flexBasis: "#{state.sideWidth}px"
       height: "#{state.height}px"
       flexDirection: 'row'

--- a/lib/Components/App.coffee
+++ b/lib/Components/App.coffee
@@ -133,6 +133,7 @@ exports.start = (root, _debugger) ->
         style:
           height: '5px'
           cursor: 'ns-resize'
+          flex: '0 0 auto' # avoid collapse of resizer (size it is an empty div it seems to easily collapse into nothing preveting the user to resize)
         'ev-mousedown': dragHandler state.channels.changeHeight, {}
       })
       h('div', {

--- a/styles/node-debugger.less
+++ b/styles/node-debugger.less
@@ -48,9 +48,12 @@ atom-text-editor::shadow {
         background-color: #FF850B;
       }
   }
+}
 
-  /* force width to zero to be able to resize to atom-text-editor element*/
-  /deep/ .scroll-view div.lines {
-      width:0px !important;
-  }
+/*
+hack: force width to zero to be able to resize to atom-text-editor element
+to solve resizing problem of console pane: https://github.com/kiddkai/atom-node-debugger/issues/109
+*/
+div.inset-panel atom-text-editor /deep/ .scroll-view div.lines {
+    width:0px !important;
 }

--- a/styles/node-debugger.less
+++ b/styles/node-debugger.less
@@ -48,4 +48,9 @@ atom-text-editor::shadow {
         background-color: #FF850B;
       }
   }
+
+  /* force width to zero to be able to resize to atom-text-editor element*/
+  /deep/ .scroll-view div.lines {
+      width:0px !important;
+  }
 }


### PR DESCRIPTION
Two problems have been fixed:
* Collapse of vertical splitter (preventing the user to change the height of the debug panels)
* Horizontal splitter failed to shrink console pane (mentioned in https://github.com/kiddkai/atom-node-debugger/issues/109)