### PR TITLE
default startup file, and new debug keymap

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,8 +11,8 @@ init:
 install:
   - cinst atom -y
   - cd %APPVEYOR_BUILD_FOLDER%
-  - %LOCALAPPDATA%/atom/bin/apm install
+  - "%LOCALAPPDATA%/atom/bin/apm install"
  
 build_script:
   - cd %APPVEYOR_BUILD_FOLDER%
-  - %LOCALAPPDATA%/atom/bin/apm test --path %LOCALAPPDATA%/atom/bin/atom
+  - "%LOCALAPPDATA%/atom/bin/apm test --path %LOCALAPPDATA%/atom/bin/atom.cmd"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,8 +11,8 @@ init:
 install:
   - cinst atom -y
   - cd %APPVEYOR_BUILD_FOLDER%
-  - apm install
+  - %LOCALAPPDATA%/atom/bin/apm install
  
 build_script:
   - cd %APPVEYOR_BUILD_FOLDER%
-  - apm test
+  - %LOCALAPPDATA%/atom/bin/apm test --path %LOCALAPPDATA%/atom/bin/atom

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ init:
   - ps: iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))
  
 install:
-  - cinst atom
+  - cinst atom -y
   - cd %APPVEYOR_BUILD_FOLDER%
   - apm install
  

--- a/keymaps/node-debugger.cson
+++ b/keymaps/node-debugger.cson
@@ -9,6 +9,7 @@
 # https://atom.io/docs/latest/advanced/keymaps
 'atom-workspace':
   'f5': 'node-debugger:start-resume'
+  'ctrl-f5': 'node-debugger:start-active-file'
   'shift-f5': 'node-debugger:stop'
   'f9': 'node-debugger:toggle-breakpoint'
   'f10': 'node-debugger:step-next'

--- a/lib/debugger.coffee
+++ b/lib/debugger.coffee
@@ -30,16 +30,17 @@ class ProcessManager extends EventEmitter
     startActive = withActiveFile
     @cleanup()
       .then =>
+        packageJSON = require @atom.project.resolvePath('package.json')
         nodePath = @atom.config.get('node-debugger.nodePath')
         nodeArgs = @atom.config.get('node-debugger.nodeArgs')
         appArgs = @atom.config.get('node-debugger.appArgs')
         port = @atom.config.get('node-debugger.debugPort')
         env = @parseEnv @atom.config.get('node-debugger.env')
-        scriptMain = @atom.project.getPaths()[0] + '/' + @atom.config.get('node-debugger.scriptMain')
+        scriptMain = @atom.project.resolvePath(@atom.config.get('node-debugger.scriptMain'))
 
-        dbgFile = scriptMain
+        dbgFile = scriptMain || packageJSON && @atom.project.resolvePath(packageJSON.main)
 
-        if startActive == true
+        if startActive == true || !dbgFile
           editor = @atom.workspace.getActiveTextEditor()
           appPath = editor.getPath()
           dbgFile = appPath

--- a/lib/debugger.coffee
+++ b/lib/debugger.coffee
@@ -7,6 +7,7 @@ childprocess = require 'child_process'
 {EventEmitter} = require './eventing'
 Event = require 'geval/event'
 logger = require './logger'
+fs = require 'fs'
 
 log = (msg) -> # console.log(msg)
 
@@ -30,7 +31,8 @@ class ProcessManager extends EventEmitter
     startActive = withActiveFile
     @cleanup()
       .then =>
-        packageJSON = require @atom.project.resolvePath('package.json')
+        packagePath = @atom.project.resolvePath('package.json')
+        packageJSON = require packagePath if fs.existsSync(packagePath)
         nodePath = @atom.config.get('node-debugger.nodePath')
         nodeArgs = @atom.config.get('node-debugger.nodeArgs')
         appArgs = @atom.config.get('node-debugger.appArgs')

--- a/lib/debugger.coffee
+++ b/lib/debugger.coffee
@@ -23,7 +23,11 @@ class ProcessManager extends EventEmitter
     result[key(e)] = value(e) for e in env.split(";")
     return result
 
-  start: (file) ->
+  startActiveFile: () ->
+    @start true
+
+  start: (withActiveFile) ->
+    startActive = withActiveFile
     @cleanup()
       .then =>
         nodePath = @atom.config.get('node-debugger.nodePath')
@@ -31,11 +35,15 @@ class ProcessManager extends EventEmitter
         appArgs = @atom.config.get('node-debugger.appArgs')
         port = @atom.config.get('node-debugger.debugPort')
         env = @parseEnv @atom.config.get('node-debugger.env')
+        defaultFile = @atom.project.getPaths()[0] + '/' + @atom.config.get('node-debugger.defaultFile')
 
-        editor = @atom.workspace.getActiveTextEditor()
-        appPath = editor.getPath()
+        dbgFile = defaultFile
 
-        dbgFile = file or appPath
+        if startActive == true
+          editor = @atom.workspace.getActiveTextEditor()
+          appPath = editor.getPath()
+          dbgFile = appPath
+
         cwd = path.dirname(dbgFile)
 
         args = []

--- a/lib/debugger.coffee
+++ b/lib/debugger.coffee
@@ -35,9 +35,9 @@ class ProcessManager extends EventEmitter
         appArgs = @atom.config.get('node-debugger.appArgs')
         port = @atom.config.get('node-debugger.debugPort')
         env = @parseEnv @atom.config.get('node-debugger.env')
-        defaultFile = @atom.project.getPaths()[0] + '/' + @atom.config.get('node-debugger.defaultFile')
+        scriptMain = @atom.project.getPaths()[0] + '/' + @atom.config.get('node-debugger.scriptMain')
 
-        dbgFile = defaultFile
+        dbgFile = scriptMain
 
         if startActive == true
           editor = @atom.workspace.getActiveTextEditor()

--- a/lib/node-debugger.coffee
+++ b/lib/node-debugger.coffee
@@ -26,9 +26,9 @@ module.exports =
     nodeArgs:
       type: 'string'
       default: ''
-    defaultFile:
+    scriptMain:
       type: 'string'
-      default: 'app.js'
+      default: ''
     appArgs:
       type: 'string'
       default: ''
@@ -68,7 +68,7 @@ module.exports =
 
   startActiveFile: =>
     if _debugger.isConnected()
-      _debugger.reqContinue()
+      return
     else
       processManager.startActiveFile()
       NodeDebuggerView.show(_debugger)

--- a/lib/node-debugger.coffee
+++ b/lib/node-debugger.coffee
@@ -26,6 +26,9 @@ module.exports =
     nodeArgs:
       type: 'string'
       default: ''
+    defaultFile:
+      type: 'string'
+      default: 'app.js'
     appArgs:
       type: 'string'
       default: ''
@@ -46,6 +49,7 @@ module.exports =
       atom.notifications.addInfo('finish debugging : )')
     @disposables.add atom.commands.add('atom-workspace', {
       'node-debugger:start-resume': @startOrResume
+      'node-debugger:start-active-file': @startActiveFile
       'node-debugger:stop': @stop
       'node-debugger:toggle-breakpoint': @toggleBreakpoint
       'node-debugger:step-next': @stepNext
@@ -60,6 +64,13 @@ module.exports =
       _debugger.reqContinue()
     else
       processManager.start()
+      NodeDebuggerView.show(_debugger)
+
+  startActiveFile: =>
+    if _debugger.isConnected()
+      _debugger.reqContinue()
+    else
+      processManager.startActiveFile()
       NodeDebuggerView.show(_debugger)
 
   toggleBreakpoint: =>

--- a/menus/node-debugger.cson
+++ b/menus/node-debugger.cson
@@ -9,6 +9,10 @@
           'command': 'node-debugger:start-resume'
         },
         {
+          'label': 'Debug Active File'
+          'command': 'node-debugger:start-active-file'
+        },
+        {
           'label': 'Stop'
           'command': 'node-debugger:stop'
         },

--- a/spec/src/debugger-spec.coffee
+++ b/spec/src/debugger-spec.coffee
@@ -22,7 +22,7 @@ describe 'ProcessManager', ->
 
       atomStub =
         project:
-          resolvePath: (file) -> '/path/to/' + file
+          resolvePath: (file) -> '/path/to/file.js'
         workspace:
           getActiveTextEditor: ->
             getPath: -> '/path/to/file.js'

--- a/spec/src/debugger-spec.coffee
+++ b/spec/src/debugger-spec.coffee
@@ -21,6 +21,8 @@ describe 'ProcessManager', ->
       }
 
       atomStub =
+        project:
+          resolvePath: (file) -> '/path/to/' + file
         workspace:
           getActiveTextEditor: ->
             getPath: -> '/path/to/file.js'


### PR DESCRIPTION
I made a thing.

I was reading this issue- https://github.com/kiddkai/atom-node-debugger/issues/103

And a few things occurred to me.
1.  i wish there was a way to specify a default entry point.
2.  i also wish there was a way to debug "my current file", when writing tests for example.
3.  i don't think the debugger should be making/enforcing assumptions about the organization or naming of the files.  standards and patterns aside.

So partially inspired by how jetBrains implements their debugger, and partially by how i just wish it always worked-  I made this.
All of this is open for review, btw.  This would be my first stab at development for atom, so all feedback is welcome.
The changes amount to-
1. configurable app entry point- defaulting to 'app.js'
2. debug hotkey uses default entry point
3. new keymap (ctrl+F5) for debugging the currently open file in the editor

![image](https://cloud.githubusercontent.com/assets/719791/11610526/21d866f4-9b73-11e5-9558-e79af79beaa7.png)

![image](https://cloud.githubusercontent.com/assets/719791/11610528/30937c1a-9b73-11e5-8d74-0a59844e806e.png)
