### PR TITLE
Display short path

### DIFF
--- a/lib/Components/BreakPointPane.coffee
+++ b/lib/Components/BreakPointPane.coffee
@@ -23,8 +23,16 @@ exports.create = (_debugger) ->
 
     breakpoint: (breakpoint) ->
       log "builder.breakpoint"
-      TreeViewItem("#{breakpoint.script} : (#{breakpoint.line+1})", handlers: { click: () -> gotoBreakpoint(breakpoint) })
-
+      TreeViewItem(
+        ((state) -> h("div", {
+            title: breakpoint.script
+            style:
+              display: 'inline'
+          }
+          ["#{atom.project.relativizePath(breakpoint.script)[1]} : (#{breakpoint.line+1})"]
+        )),
+        handlers: { click: () -> gotoBreakpoint(breakpoint) }
+      )
     root: () ->
       TreeView("Breakpoints", (() -> builder.listBreakpoints().map(builder.breakpoint)), isRoot: true)
 

--- a/lib/Components/BreakPointPane.coffee
+++ b/lib/Components/BreakPointPane.coffee
@@ -4,7 +4,7 @@ Promise = require 'bluebird'
 
 log = (msg) -> #console.log(msg)
 
-{TreeView, TreeViewItem} = require './TreeView'
+{TreeView, TreeViewItem, TreeViewUtils} = require './TreeView'
 
 gotoBreakpoint = (breakpoint) ->
   atom.workspace.open(breakpoint.script, {
@@ -24,13 +24,7 @@ exports.create = (_debugger) ->
     breakpoint: (breakpoint) ->
       log "builder.breakpoint"
       TreeViewItem(
-        ((state) -> h("div", {
-            title: breakpoint.script
-            style:
-              display: 'inline'
-          }
-          ["#{atom.project.relativizePath(breakpoint.script)[1]} : (#{breakpoint.line+1})"]
-        )),
+        TreeViewUtils.createFileRefHeader breakpoint.script, breakpoint.line+1
         handlers: { click: () -> gotoBreakpoint(breakpoint) }
       )
     root: () ->

--- a/lib/Components/CallStackPane.coffee
+++ b/lib/Components/CallStackPane.coffee
@@ -3,7 +3,7 @@ Promise = require 'bluebird'
 hg = require 'mercury'
 fs = require 'fs'
 {EventEmitter} = require 'events'
-
+{h} = hg
 
 #######################################
 
@@ -96,7 +96,13 @@ exports.create = (_debugger) ->
     frame: (frame) ->
       log "builder.frame #{frame.script.name}, #{frame.script.line}"
       return TreeView(
-          "#{frame.script.name}:#{frame.line + 1}",
+          ((state) -> h('div', {
+            title: frame.script.name
+            style:
+              display: 'inline'
+            },
+            ["#{atom.project.relativizePath(frame.script.name)[1]}:#{frame.line + 1}"]
+          ))
           (() =>
             Promise.resolve([
               TreeView("arguments", (() => Promise.resolve(frame.arguments).map(builder.value)))

--- a/lib/Components/CallStackPane.coffee
+++ b/lib/Components/CallStackPane.coffee
@@ -1,5 +1,5 @@
 Promise = require 'bluebird'
-{TreeView, TreeViewItem} = require './TreeView'
+{TreeView, TreeViewItem, TreeViewUtils} = require './TreeView'
 hg = require 'mercury'
 fs = require 'fs'
 {EventEmitter} = require 'events'
@@ -96,13 +96,7 @@ exports.create = (_debugger) ->
     frame: (frame) ->
       log "builder.frame #{frame.script.name}, #{frame.script.line}"
       return TreeView(
-          ((state) -> h('div', {
-            title: frame.script.name
-            style:
-              display: 'inline'
-            },
-            ["#{atom.project.relativizePath(frame.script.name)[1]}:#{frame.line + 1}"]
-          ))
+          TreeViewUtils.createFileRefHeader frame.script.name, frame.line + 1
           (() =>
             Promise.resolve([
               TreeView("arguments", (() => Promise.resolve(frame.arguments).map(builder.value)))

--- a/lib/Components/TreeView.coffee
+++ b/lib/Components/TreeView.coffee
@@ -88,7 +88,7 @@ TreeViewItem = (value, { handlers, data } = {}) -> hg.state({
   })
 
 TreeViewItem.render = (state) ->
-  h('li.list-item.entry', { 'ev-click': hg.send state.channels.click }, [state.value])
+  h('li.list-item.entry', { 'ev-click': hg.send state.channels.click }, [state.value?(state) ? state.value])
 
 exports.TreeView = TreeView
 exports.TreeViewItem = TreeViewItem

--- a/lib/Components/TreeView.coffee
+++ b/lib/Components/TreeView.coffee
@@ -90,5 +90,16 @@ TreeViewItem = (value, { handlers, data } = {}) -> hg.state({
 TreeViewItem.render = (state) ->
   h('li.list-item.entry', { 'ev-click': hg.send state.channels.click }, [state.value?(state) ? state.value])
 
+class TreeViewUtils
+  @createFileRefHeader: (fullPath, line) ->
+        return (state) -> h("div", {
+            title: fullPath
+            style:
+              display: 'inline'
+          }
+          ["#{atom.project.relativizePath(fullPath)[1]} : #{line}"]
+        )
+
 exports.TreeView = TreeView
 exports.TreeViewItem = TreeViewItem
+exports.TreeViewUtils = TreeViewUtils


### PR DESCRIPTION
It is a waste of screen space and it clutters the ui to display the full file path in the callstack pane and the break point pane. Now only a project relative path is displayd. Full path is available as a tool tip.